### PR TITLE
chore: go support combine all coverage file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -52,22 +52,11 @@ pipeline:
     when:
       event: [ tag ]
 
-  generate-coverage:
-    image: golang:1.12
-    pull: true
-    environment:
-      TAGS: bindata
-    commands:
-      - make coverage
-    when:
-      event: [ push, pull_request ]
-      branch: [ master ]
-
   coverage:
     image: robertstettner/drone-codecov
     secrets: [ codecov_token ]
     files:
-      - coverage.all
+      - coverage.out
     when:
       event: [ push, pull_request ]
       branch: [ master ]

--- a/Makefile
+++ b/Makefile
@@ -70,13 +70,6 @@ fmt:
 vet:
 	$(GO) vet $(PACKAGES)
 
-.PHONY: errcheck
-errcheck:
-	@hash errcheck > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		$(GO) get -u github.com/kisielk/errcheck; \
-	fi
-	errcheck $(PACKAGES)
-
 .PHONY: lint
 lint:
 	@hash revive > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
@@ -111,13 +104,6 @@ fmt-check:
 .PHONY: test
 test:
 	GO111MODULE=on $(GO) test -mod=vendor -tags='sqlite sqlite_unlock_notify' $(PACKAGES)
-
-.PHONY: coverage
-coverage:
-	@hash gocovmerge > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		$(GO) get -u github.com/wadey/gocovmerge; \
-	fi
-	gocovmerge $(shell find . -type f -name "coverage.out") > coverage.all;\
 
 .PHONY: unit-test-coverage
 unit-test-coverage:

--- a/README.md
+++ b/README.md
@@ -4,26 +4,32 @@ This project acts as a command line tool for operating one or multiple Gitea ins
 the Gitea API implementation.
 
 ## Installation
+
 Currently no prebuilt binaries are provided.
 To install, a Go installation is needed.
+
 ```sh
 go get code.gitea.io/tea
 go install code.gitea.io/tea
 ```
 
 If the `tea` executable is not found, you might need to set up your `$GOPATH` and `$PATH` variables first:
+
 ```sh
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 ```
 
 ## Usage
+
 First of all, you have to create a token on your `personal settings -> application` page of your gitea instance.
 Use this token to login with `tea`:
+
 ```sh
 tea login add --name=try --url=https://try.gitea.io --token=xxxxxx
 ```
 
 Now you can use the `tea` commands:
+
 ```sh
 tea issues
 tea releases
@@ -34,6 +40,7 @@ tea releases
 ## Compilation
 
 To compile the sources yourself run the following:
+
 ```sh
 go get code.gitea.io/tea
 cd "${GOPATH}/src/code.gitea.io/tea"


### PR DESCRIPTION
* Combine all coverage file in one command
* remove generate-coverage
* remove unused method: errCheck

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>